### PR TITLE
[add] num command

### DIFF
--- a/src/parse_number.typ
+++ b/src/parse_number.typ
@@ -1,0 +1,49 @@
+
+// float, int string or content
+#let get-num-str(number, decimal-marker) = {
+  let result = lower(repr(number).trim("[").trim("]"))
+  result = result.replace(",", decimal-marker)
+  result = result.replace(".", decimal-marker)
+  if result.ends-with(decimal-marker) { result += "0" }
+  return result
+}
+
+#let get-decimal-pos(str, decimal-marker) = {
+  let decimal-pos = str.position(decimal-marker)
+  if decimal-pos == none { decimal-pos = str.len() }
+  return decimal-pos
+}
+#let get-num-decimals(str, decimal-marker) = {
+  let decimal-pos = str.position(decimal-marker)
+  if decimal-pos != none { return str.len() - decimal-pos - 1 }
+  return 0
+}
+
+#let group-digits(input, group-size, group-sep, group-min-digits, decimal-marker) = {
+  let decimal-pos = get-decimal-pos(input, decimal-marker)
+  let effective-group-size = group-size
+  if decimal-pos < group-min-digits {
+    effective-group-size = group-min-digits
+  }
+  let index = effective-group-size - calc.rem(decimal-pos, effective-group-size)
+  let result = ""
+  let i = 0
+  for k in input {      
+    if k == decimal-marker { 
+      effective-group-size = group-size
+      if input.len() - decimal-pos <= group-min-digits {
+        effective-group-size = group-min-digits
+      }
+      index = effective-group-size - 1
+      i = -1 
+    } else if calc.rem(index, effective-group-size) == 0 and i != 0 {
+      result += group-sep 
+    }
+    result += k
+    index += 1
+    i += 1
+  }
+  return result
+}
+
+

--- a/tests/num_tests.typ
+++ b/tests/num_tests.typ
@@ -1,0 +1,67 @@
+#import "/src/lib.typ": num, qty
+
+=== Test output decimal marker
+
+#table(columns: 3,
+  [], [Output `.`], [Output `,`],
+  [Input `.`], num[1.0], num(decimal-marker: ",")[1.0],  
+  [Input `,`], num[1,0], num(decimal-marker: ",")[1,0],  
+)
+
+
+=== Test group digits
+
+#let examples = ([1], [10], [100], [1000], [10000], [0.1], [0.01], [0.001], [0,0001], [100000,00001])
+
+#{
+  set text(size: .8em)
+  let num1 = num.with(groupmindigits: 0)
+  table(columns: examples.len() + 1,
+    [`group-digits: false`], ..examples.map(x => num1(x, group-digits: false)),
+    [`group-size: 2`], ..examples.map(x => num1(x, group-size: 2, group-sep: "'")),
+    [`group-size: 3`], ..examples.map(x => num1(x, group-sep: "'")),
+    [`group-size: 4`], ..examples.map(x => num1(x, group-size: 4, group-sep: "'")),
+    [`group-sep: space.thin`], ..examples.map(x => num1(x)),
+    [`groupmindigits: 5`], ..examples.map(x => num(x, group-sep: "'")),
+  )
+}
+
+=== Test inline exponential
+
+#table(columns: 3,
+  num[1e10], num[1e-10], num[1e+10]
+)
+
+=== Test uncertainty automatic precision
+
+#table(columns: 4,
+  num(pm: 0.2)[1], num(pm: 0.2)[1.], num(pm: 0.2)[1.0], num(pm: 0.2)[1.00],
+  num(pm: 2)[10], num(pm: 200)[10], num(pm: 2)[1000], [],
+  num(pm: 1)[1], num(pm: 1)[1.], [], [],
+  num(pm: 1)[-1], num(pm: 1)[-1.], [], [],
+)
+
+=== Test implicit plus
+
+#table(columns: 2,
+  num(implicit-plus: true)[33e2],
+  num(implicit-plus: true)[-33e2]
+)
+
+=== Test parentheses around uncertainty when exponent is given
+#num(pm: 0.2, e: 2)[1]
+
+
+=== Test normal vs. tight
+
+#let examples = (
+  ([1],[1]),
+  ([1e2],none),
+  ([1e2],[1.0]),
+  )
+#table(columns: examples.len() + 1,
+  [`tight: false`], ..examples.map(x => num(x.at(0), pm: x.at(1))),
+  [`tight: true`], ..examples.map(x => num(x.at(0), pm: x.at(1), tight: true)),  
+)
+
+#qty([2000000], "m", group-digits: false, implicit-plus: true)


### PR DESCRIPTION
- proper number parsing
- digit grouping options
- customizable decimal-marker
- uncertainty: automatically equalize precision between value and uncertainty
- tight number formatting
- implicit + in front of positive numbers -

Also fixes:
- parentheses around number in combination with num

Also adds:
- allow-breaking for qty


Actually I noticed, the `_state` dictionary need not contain any default keys if the internal `_unit` and `num-impl` functions have default values for these keys (see the definition of `num-impl`). This way, the `_state` contains less key-value pairs in most cases and the overhead of updating the '..options' in `num`, `qty` and `unit` is reduced. This could also be applied to '_unit' in a similar fashion. 

